### PR TITLE
Fix broken ABTest component example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -88,7 +88,7 @@
     var VariationExperiment = React.createClass({
       render: function() {
         return (
-            <ReactExperiments.ABTest experiment={window.demo} on='foo'>
+            <ReactExperiments.ABTest experiment={window.demo} experimentName='SampleExperiment' on='foo'>
               <ReactExperiments.When value='Variation A'>
                 Variation A
               </ReactExperiments.When>


### PR DESCRIPTION
Prevents the following error and allows the ```ABTest``` example to render:

<img width="1435" alt="screen shot 2015-09-25 at 2 08 30 pm" src="https://cloud.githubusercontent.com/assets/3450569/10108461/fb211fe0-638e-11e5-8169-a6e3920c8ad8.png">

---
@rawls238 @gusvargas 